### PR TITLE
fix: use old-style loops

### DIFF
--- a/jsonnetsecure/jsonnet_pool.go
+++ b/jsonnetsecure/jsonnet_pool.go
@@ -65,7 +65,7 @@ func NewProcessPool(size int) Pool {
 	if err != nil {
 		panic(err) // this should never happen, see implementation of puddle.NewPool
 	}
-	for range size {
+	for i := 1; i <= size; i++ {
 		// warm pool
 		go pud.CreateResource(context.Background())
 	}

--- a/reqlog/external_latency_test.go
+++ b/reqlog/external_latency_test.go
@@ -24,7 +24,7 @@ func TestExternalLatencyMiddleware(t *testing.T) {
 			var wg sync.WaitGroup
 
 			wg.Add(3)
-			for i := range 3 {
+			for i := 1; i <= 3; i++ {
 				ctx := r.Context()
 				if i%3 == 0 {
 					ctx = WithDisableExternalLatencyMeasurement(ctx)


### PR DESCRIPTION
Use the old-style loops for Go 1.21